### PR TITLE
Adopt hypeman-social 0.1.0 from PyPI; document the shared LLM layer

### DIFF
--- a/Docker/requirements.txt
+++ b/Docker/requirements.txt
@@ -11,8 +11,7 @@
 # generation (Ollama/Gemini with failover + guardrails), config/secrets.
 # Extras pull the pinned-in-hypeman SDKs: atproto, grapheme, Mastodon.py,
 # ollama, google-genai, beautifulsoup4, boto3, hvac, doppler-sdk.
-# TODO: switch to `hypeman-social[all,aws,vault,doppler]>=0.1.0` once on PyPI.
-hypeman-social[all,aws,vault,doppler] @ https://github.com/ChiefGyk3D/hypeman/archive/126c28b5da4901e8ca102955193b71652ec9d348.tar.gz
+hypeman-social[all,aws,vault,doppler]>=0.1.0,<0.2
 
 twitchAPI==4.5.0
 python-dotenv==1.2.2

--- a/README.md
+++ b/README.md
@@ -162,6 +162,23 @@ See [docs/features/llm-model-recommendations.md](docs/features/llm-model-recomme
 - **Quality logging** - Clear visibility into issues and retry outcomes
 - See [docs/features/llm-guardrails.md](docs/features/llm-guardrails.md) for full details
 
+**🔁 Provider Failover & Auto-Recovery (via [hypeman-social](https://github.com/ChiefGyk3D/hypeman)):**
+
+The AI layer is powered by [`hypeman-social`](https://pypi.org/project/hypeman-social/),
+the shared library behind Boon-Tube-Daemon, Star-Daemon, and yomama-as-a-service —
+a fix that lands there protects every daemon at once. It adds two things the
+old built-in providers couldn't do:
+
+- **Automatic reconnection** — taking your Ollama box offline costs you
+  template-fallback posts, not a daemon restart. The daemon keeps probing and
+  picks the model back up the moment the server returns.
+- **Opt-in failover** — set `LLM_FALLBACK_PROVIDER=gemini` and a local outage
+  fails over to the cloud (strictly opt-in, so local-only stays local), then
+  switches back automatically when your box recovers. Use
+  `LLM_OLLAMA_MODEL` / `LLM_GEMINI_MODEL` so each provider names its own model.
+
+Full key reference: [hypeman-social configuration docs](https://github.com/ChiefGyk3D/hypeman/blob/main/docs/CONFIGURATION.md).
+
 ### 🔐 Enterprise-Grade Secrets Management
 - **Doppler** - Modern secrets platform with environment-specific tokens (dev/staging/prod)
 - **AWS Secrets Manager** - Secure cloud-based credential storage with IAM integration

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,7 @@
 # generation (Ollama/Gemini with failover + guardrails), config/secrets.
 # Extras pull the pinned-in-hypeman SDKs: atproto, grapheme, Mastodon.py,
 # ollama, google-genai, beautifulsoup4, boto3, hvac, dopplersdk.
-# TODO: switch to `hypeman-social[all,aws,vault,doppler]>=0.1.0` once on PyPI.
-hypeman-social[all,aws,vault,doppler] @ https://github.com/ChiefGyk3D/hypeman/archive/126c28b5da4901e8ca102955193b71652ec9d348.tar.gz
+hypeman-social[all,aws,vault,doppler]>=0.1.0,<0.2
 
 twitchAPI==4.5.0
 python-dotenv==1.2.2


### PR DESCRIPTION
`hypeman-social` is now [published on PyPI](https://pypi.org/project/hypeman-social/), so the commit-tarball pin becomes a proper version range in both requirements files (root and `Docker/`): `hypeman-social[all,aws,vault,doppler]>=0.1.0,<0.2` (0.x minors may break, per the library's versioning policy — hence the upper bound).

README's AI section gains a **Provider Failover & Auto-Recovery** subsection: automatic reconnection when the Ollama box returns, opt-in `LLM_FALLBACK_PROVIDER` with automatic switch-back, per-provider model keys, and a link to the library's [full configuration reference](https://github.com/ChiefGyk3D/hypeman/blob/main/docs/CONFIGURATION.md).

Tests: 107 passed, 61 skipped locally; the PyPI spec verified resolvable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh6asJV76z7de9zejpmQwK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qh6asJV76z7de9zejpmQwK)_