### PR TITLE
deps: bump hypeman-social to >=0.2.0,<0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@
 # generation (Ollama/Gemini with failover + guardrails), config/secrets.
 # Extras pull the pinned-in-hypeman SDKs: atproto, grapheme, Mastodon.py,
 # ollama, google-genai, beautifulsoup4, boto3, hvac, dopplersdk.
-hypeman-social[all,aws,vault,doppler]>=0.1.0,<0.2
+hypeman-social[all,aws,vault,doppler]>=0.2.0,<0.3
 
 twitchAPI==4.5.0
 python-dotenv==1.2.2


### PR DESCRIPTION
## What this does

Bumps the `hypeman-social[all,aws,vault,doppler]` pin from `>=0.1.0,<0.2` to `>=0.2.0,<0.3` now that [v0.2.0](https://github.com/ChiefGyk3D/hypeman/releases/tag/v0.2.0) is on PyPI.

0.2.0 is fully additive over 0.1.x — no code changes needed here. What the daemon gains: `ThreadsPlatform` available via the registry (enable with `THREADS_ENABLE_POSTING`), `LLMManager.generate_validated()`, `py.typed` for type checking, and the star-embed rendering (unused here but harmless).

## Validation

- `hypeman-social==0.2.0` verified downloadable from PyPI.
- CI installs from PyPI (now from the single root `requirements.txt`) and runs the full suite plus the Docker build with its smoke import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh6asJV76z7de9zejpmQwK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qh6asJV76z7de9zejpmQwK)_